### PR TITLE
FOGL-2816 RPM packaging & requirements.sh file updated

### DIFF
--- a/Description
+++ b/Description
@@ -1,0 +1,1 @@
+FogLAMP South TI SensorTag CC2650 plugin

--- a/Package
+++ b/Package
@@ -1,0 +1,26 @@
+# A set of variables that define how we package this repository
+#
+plugin_name=cc2650
+plugin_type=south
+plugin_install_dirname=${plugin_name}
+
+# Now build up the runtime requirements list. This has 3 components
+#   1. Generic packages we depend on in all architectures and package managers
+#   2. Architecture specific packages we depend on
+#   3. Package manager specific packages we depend on
+requirements="foglamp,bluez"
+
+case "$arch" in
+	x86_64)
+		;;
+	armhf)
+		;;
+	aarch64)
+		;;
+esac
+case "$package_manager" in
+	deb)
+		;;
+	rpm)
+		;;
+esac

--- a/requirements.sh
+++ b/requirements.sh
@@ -22,5 +22,20 @@
 
 set -e
 
-sudo apt install -y bluez
-pip3 install -Ir python/requirements-cc2650.txt --no-cache-dir
+os_name=`(grep -o '^NAME=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')`
+os_version=`(grep -o '^VERSION_ID=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')`
+echo "Platform is ${os_name}, Version: ${os_version}"
+
+if [[ ( $os_name == *"Red Hat"* || $os_name == *"CentOS"* ) &&  $os_version == *"7"* ]]; then
+	sudo yum -y install bluez
+elif apt --version 2>/dev/null; then
+	sudo apt -y install bluez
+else
+	echo "Requirements cannot be automatically installed, please refer README.rst to install requirements manually"
+fi
+
+if pip3 --version 2>/dev/null; then
+    pip3 install -Ir python/requirements-cc2650.txt --no-cache-dir
+else
+    echo "pip3 package is not installed, please install it and then run python/requirements-cc2650.txt manually with pip3"
+fi


### PR DESCRIPTION
**$ ./make_plugin_rpm -b develop foglamp-south-cc2650** (repo already cloned in my environment)

```
WARNING: Repository foglamp-south-cc2650 already exists, using the existing copy
Your branch is up-to-date with 'origin/develop'.
Version is 1.5.2
The package root directory is                        : /tmp/foglamp-south-cc2650
The FogLAMP south cc2650 version is : 1.5.2
The package will be built in                         : /tmp/foglamp-south-cc2650/packages/build
The package name is                                  : foglamp-south-cc2650-1.5.2

Saving the old working environment as foglamp-south-cc2650-1.5.2.0001
Populating the package and updating version file...Done.
Building the new package...
Processing files: foglamp-south-cc2650-1.5.2-1.x86_64
Checking for unpackaged file(s): /usr/lib/rpm/check-files /tmp/foglamp-south-cc2650/packages/build/foglamp-south-cc2650-1.5.2/BUILDROOT/foglamp-south-cc2650-1.5.2-1.x86_64
Wrote: /tmp/foglamp-south-cc2650/packages/build/foglamp-south-cc2650-1.5.2/RPMS/x86_64/foglamp-south-cc2650-1.5.2-1.x86_64.rpm
Building Complete.

``` 

**$ rpm -i --test -v -v archive/x86_64/foglamp-south-cc2650-1.5.2-1.x86_64.rpm** 

```
ufdio:       1 reads,    15439 total bytes in 0.000019 secs
rpm: RPM should not be used directly install RPM packages, use Alien instead!
rpm: However assuming you know what you are doing...
D: ============== archive/x86_64/foglamp-south-cc2650-1.5.2-1.x86_64.rpm
D: loading keyring from pubkeys in /home/foglamp/.rpmdb/pubkeys/*.key
D: couldn't find any keys in /home/foglamp/.rpmdb/pubkeys/*.key
D: loading keyring from rpmdb
D: opening  db environment /home/foglamp/.rpmdb cdb:0x401
D: opening  db index       /home/foglamp/.rpmdb/Packages 0x400 mode=0x0
D: locked   db index       /home/foglamp/.rpmdb/Packages
D: opening  db index       /home/foglamp/.rpmdb/Name 0x400 mode=0x0
D: Expected size:        19547 = lead(96)+sigs(4292)+pad(4)+data(15155)
D:   Actual size:        19547
D: archive/x86_64/foglamp-south-cc2650-1.5.2-1.x86_64.rpm: Header SHA1 digest: OK (34af7d793f0cf84f565c3a3164df63cd371baa2c)
ufdio:       6 reads,     9775 total bytes in 0.000036 secs
D: 	added binary package [0]
D: found 0 source and 1 binary packages
D: opening  db index       /home/foglamp/.rpmdb/Conflictname 0x400 mode=0x0
D: opening  db index       /home/foglamp/.rpmdb/Requirename 0x400 mode=0x0
D: ========== +++ foglamp-south-cc2650-1.5.2-1 x86_64/linux 0x0
D: opening  db index       /home/foglamp/.rpmdb/Basenames 0x400 mode=0x0
D: opening  db index       /home/foglamp/.rpmdb/Providename 0x400 mode=0x0
D:  Requires: /bin/sh                                       NO  
D:  Requires: /bin/sh                                       NO  (cached)
D:  Requires: /bin/sh                                       NO  
D:  Requires: /bin/sh                                       NO  (cached)
D:  Requires: /bin/sh                                       NO  
D:  Requires: bluez                                         NO  
D:  Requires: foglamp >= 1.5                                NO  
D:  Requires: rpmlib(CompressedFileNames) <= 3.0.4-1        YES (rpmlib provides)
D:  Requires: rpmlib(PayloadFilesHavePrefix) <= 4.0-1       YES (rpmlib provides)
D: opening  db index       /home/foglamp/.rpmdb/Obsoletename 0x400 mode=0x0
error: Failed dependencies:
	/bin/sh is needed by foglamp-south-cc2650-1.5.2-1.x86_64
	bluez is needed by foglamp-south-cc2650-1.5.2-1.x86_64
	foglamp >= 1.5 is needed by foglamp-south-cc2650-1.5.2-1.x86_64
D: closed   db index       /home/foglamp/.rpmdb/Packages
D: closed   db index       /home/foglamp/.rpmdb/Obsoletename
D: closed   db index       /home/foglamp/.rpmdb/Conflictname
D: closed   db index       /home/foglamp/.rpmdb/Providename
D: closed   db index       /home/foglamp/.rpmdb/Requirename
D: closed   db index       /home/foglamp/.rpmdb/Basenames
D: closed   db index       /home/foglamp/.rpmdb/Name
D: closed   db environment /home/foglamp/.rpmdb

```